### PR TITLE
fix typo for the file name in patch 3 instructions

### DIFF
--- a/assignments/E2.md
+++ b/assignments/E2.md
@@ -26,7 +26,7 @@ how to write good tests, and how to develop code using tests as a guide
 
 * Patch 2 adds `username/E2/test.c`, your original testing program, and `username/E2/Makefile`, which builds your testing program as `test` via the default and `test` targets
 
-* Patch 3 adds `username/E2/module.c` and modifies the makefile to build `username/E2/kdlp.ko` via the default and `module` targets
+* Patch 3 adds `username/E2/kdlp.c` and modifies the makefile to build `username/E2/kdlp.ko` via the default and `module` targets
 
 * Don't forget a cover letter
 


### PR DESCRIPTION
Instructions say that patch 3 adds `username/E2/module.c` file, however file name should be `kdlp.c`.