### PR TITLE
Separate makefiles for userspace code in E2 and P2

### DIFF
--- a/assignments/E2.md
+++ b/assignments/E2.md
@@ -110,7 +110,7 @@ that it will create in `/proc`
 
     * The makefile's default and `module` targets must build a kernel object file named `kdlp.ko`
 
-    * The makefile's load and unload targets must load and unload your module respectively
+    * The makefile's `load` and `unload` targets must load and unload your module respectively
 
     * The makefile's `clean` target must remove the module build artifacts and should return success even when no artifacts exist to be deleted
 

--- a/assignments/E2.md
+++ b/assignments/E2.md
@@ -24,9 +24,9 @@ how to write good tests, and how to develop code using tests as a guide
 
 * Patch 1 adds `username/E2/specification.txt`, a filled out copy of `E2.txt`
 
-* Patch 2 adds `username/E2/test.c`, your original testing program, and `username/E2/Makefile`, which builds your testing program as `test` via the default and `test` targets
+* Patch 2 adds `username/E2/tests/test.c`, your original testing program, and `username/E2/tests/Makefile`, which builds your testing program as `test` via the default and `test` targets
 
-* Patch 3 adds `username/E2/kdlp.c` and modifies the makefile to build `username/E2/kdlp.ko` via the default and `module` targets
+* Patch 3 adds `username/E2/kdlp.c` and a new makefile to build `username/E2/kdlp.ko` via the default and `module` targets
 
 * Don't forget a cover letter
 
@@ -49,9 +49,18 @@ according to the specification
 by performing operations on the file
 that it will create in `/proc`
 
+    * Create a `tests/` directory in `username/E2`
+
     * Your test program must be named `test.c`
-    and your makefile must build an executable
+    and placed in `username/E2/tests/`
+
+    * Create a makefile in your `username/E2/tests/`
+    directory that builds an executable
     named `test` as the default target and `test` target
+
+    * The makefile's `clean` target must remove the test
+    build artifacts and should return success even when no
+    artifacts exist to be deleted
 
     * The standard output from your testing program must
     comply with the Test Anything Protocol version 14.
@@ -97,14 +106,13 @@ that it will create in `/proc`
 
     * The `/proc` file must be accessible at `/proc/kdlp`
 
-    * Update your makefile so it can build/clean,
-    load/unload, and test your kernel module
+    * Create a makefile in your `username/E2/` directory to build/clean and load/unload your module
 
     * The makefile's default and `module` targets must build a kernel object file named `kdlp.ko`
 
     * The makefile's load and unload targets must load and unload your module respectively
 
-    * The makefile's `clean` target must remove both test and module build artifacts and should return success even when no artifacts exist to be deleted
+    * The makefile's `clean` target must remove the module build artifacts and should return success even when no artifacts exist to be deleted
 
     * The kernel code in
 [`fs/proc/cmdline.c`](https://elixir.bootlin.com/linux/v6.11/source/fs/proc/cmdline.c)

--- a/assignments/P2.md
+++ b/assignments/P2.md
@@ -20,8 +20,8 @@ Solve a puzzle and uncover the secret message by demonstrating your knowledge of
 
     * Add the files to git and make your first commit
 
-* Patch 2 adds `username/P2/solution.c`, your solution program,
-and modifies the makefile `username/P2/Makefile` to build `solution.c` into an executable named `solution` via the default target
+* Patch 2 adds `username/P2/solution/solution.c`, your solution program,
+and a makefile `username/P2/solution/Makefile` to build `solution.c` into an executable named `solution` via the default target
 
     * Write a C program that performs the right sequence of operations on `/dev/ctf` so that the messages from the driver in `dmesg` match the provided output in `dmesg_log`
 


### PR DESCRIPTION
This PR is an attempt to address the issue from charliemirable:

" it is messy to try and add code to build a module to a makefile for building userspace code. The modifications to CC and CFLAGS that you might want to use while building userspace might interfere with the kernel build process.

At least E2 should be updated with a separate test folder like F2, and probably P2 as well"

2 commits are included, one for modifications to E2 and one for modifications to P2. Both instruct students to include separate makefiles for userspace and kernelspace code. This is achieved in E2 by requiring the test.c file with its own makefile in a folder called tests/ inside the student's username/E2 directory and in P2 by requiring the unmodified ctf.c and Makefile to be copied into a folder called ctf/ inside the student's username/P2 directory.