### PR TITLE
Add requirement for assignment prefix and imperative tense in commit …

### DIFF
--- a/assignments/setup.md
+++ b/assignments/setup.md
@@ -187,8 +187,9 @@ make a commit to save this version of the repository so it can be shared with `g
 Note that the `-s` flag makes git include the `Signed-off-by` DCO line for you automatically.
 
 Git will then open an instance of your preferred text editor to let you input a message for the commit.
-Put a title containing a short summary of what you did on the first line,
-e.g. `Setup: Added introduction for so and so`.
+On the first line, put a title beginning with the assignment prefix followed by a colon and a space,
+then a short summary of what you did in the imperative tense.,
+e.g. `Setup: Add introduction for so and so`.
 Press enter twice,
 and then write a more detailed explanation that will act as the body of the commit.
 

--- a/procedures.md
+++ b/procedures.md
@@ -250,8 +250,9 @@ and by hitting enter twice and leaving a blank line the subsequent text will bec
 commit message. The `git format-patch` utility will automatically put the title and message
 of a commit into the respective title and body of the corresponding generated email patch file.
 
-Your commits should have a title that is a short summary of the changes in this commit and you
-should include any further details in the commit message.
+The commit title should include the assignment prefix followed by a colon and a space,
+then a short summary of the changes in this commit in the imperative tense.
+e.g. `E0: Add username/E0.txt`. Any further details should be included in the commit message.
 
 You should make sure that the changes you are including in your commits are tidy.
 This means that code should follow the


### PR DESCRIPTION
Add requirement for assignment prefix and imperative tense in commit title.

Adjusted instructions in procedures.md and assignments/setup.md to reflect that commit titles should include the assignment prefix, and be in the imperative tense.

Fixes: #5 