### PR TITLE
Address Issue 21 - typo on slide 33 of slides/chardevs2.md

### DIFF
--- a/slides/chardevs2.md
+++ b/slides/chardevs2.md
@@ -352,7 +352,7 @@ Use read system call on any /dev/kkeyXXX
 
 # An analogy
 
-If the timer interupt is the "heartbeat" of the kernel, then `kkey` reads it's pulse
+If the timer interrupt is the "heartbeat" of the kernel, then `kkey` reads it's pulse
 
 1. This is not rigorous
 


### PR DESCRIPTION
Fixes typo `interupt` in slides/chardevs2.md

Addresses issue #21 