### PR TITLE
Remove line stating ksys_lseek removed entirely from fd4

### DIFF
--- a/slides/fd4.md
+++ b/slides/fd4.md
@@ -42,8 +42,6 @@ While file descriptors are prefered as a userspace interface, the kernel is bett
 
 [`ksys_write()` removed from init/do_mounts_rd.c](https://github.com/torvalds/linux/commit/bef173299613404f55b11180d9a865861637f31d)
 
-1. Notice that `ksys_lseek()` is entirely removed
-
 ---
 
 # The other kernel interface


### PR DESCRIPTION
Deleted the line stating that ksys_lseek was removed entirely from slides/fd4.md

Addresses issue #44 
Note: ksys_lseek not mentioned in slides/fd3.md.