### PR TITLE
Make all shell commands use consisten prefix in assignments

### DIFF
--- a/assignments/E0.md
+++ b/assignments/E0.md
@@ -32,35 +32,35 @@ mean running `make clean` and losing your progress in the compilation.
 
 0. First, install the requisite dependencies. On Fedora, you can use
 
-        sudo dnf builddep kernel
+        $ sudo dnf builddep kernel
 
     which is roughly equivalent to
 
-        sudo dnf -y install gcc flex make bison openssl openssl-devel elfutils-libelf-devel ncurses-devel bc git tar dwarves
+        $ sudo dnf -y install gcc flex make bison openssl openssl-devel elfutils-libelf-devel ncurses-devel bc git tar dwarves
 
     It's also recommended to install ccache to speed up subsequent kernel builds
 by running
 
-        sudo dnf -y install ccache
+        $ sudo dnf -y install ccache
     *Be sure to restart your terminal after installing ccache
 so that it gets added to your path!*
 
 0. Clone the v6.11 Linux kernel release from [git.kernel.org](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git).
 It's recommended to set `--depth=1` to minimize the download size.
 
-        git clone --depth=1 --branch v6.11 https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+        $ git clone --depth=1 --branch v6.11 https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 
     When this completes, change the current directory to the kernel tree with
 
-        cd linux
+        $ cd linux
 
 0. Copy the kernel config for your running kernel to your kernel source tree with
 
-        cp /boot/config-$(uname -r) .config
+        $ cp /boot/config-$(uname -r) .config
 
     and set any new config options to the defaults with
 
-        make olddefconfig
+        $ make olddefconfig
 
 0. Set a custom version tag for your kernel build.
 Create a file named `localversion` in the `linux` directory and add something cool.
@@ -75,7 +75,7 @@ For example, `cat localversion` might return
 
 0. Now, build the kernel by running
 
-        make -j $(nproc)
+        $ make -j $(nproc)
 
     The `-j` option will invoke a parallel build using the number of threads specified.
 The `$(nproc)` will resolve to the output of the `nproc` command,
@@ -88,15 +88,15 @@ The directories you will be writing to are owned by root,
 so you need superuser permission (granted by wrapping your command with `sudo`)
 in order to complete this step.
 
-        sudo make -j $(nproc) modules_install
+        $ sudo make -j $(nproc) modules_install
 
 0. Finally, install the new kernel into your system's `/boot` directory. The same superuser considerations from the previous step apply.
 
-        sudo make install
+        $ sudo make install
 
     When this completes, shutdown your VM.
 
-        sudo shutdown now
+        $ sudo shutdown now
 
 0. Power on your system again. You should see a menu that looks roughly like the following:
 
@@ -110,20 +110,20 @@ Use the arrow keys to select your newly built kernel with your custom tag and hi
 
 0. If you would like to set your new kernel as the default (i.e. it will boot automatically without selecting it at the menu), then use the following command to locate the index associated with your new kernel
 
-        sudo grubby --info ALL
+        $ sudo grubby --info ALL
 
     Then, set the default to the index of your new kernel
 
-        sudo grubby --set-default-index <index>
+        $ sudo grubby --set-default-index <index>
 
 0. When you have booted into your new kernel and logged in, make a copy of `E0.txt`
 in the `yourname/E0` directory and answer the questions inside.
 
 0. Run the following commands and save their output for the assignment submission.
 
-        uname -a
+        $ uname -a
 
-        sudo dmesg | head
+        $ sudo dmesg | head
 
     Note that your editor likely allows you to directly dump the output of these commands into `E0.txt`.
 In `nano` this is accomplished via `ctrl+t`, and in `vim` you would use `:r! command`.

--- a/assignments/E1.md
+++ b/assignments/E1.md
@@ -62,7 +62,7 @@ userspace and kernelspace and document your observations.
 
     0. Use this to answer question 1
 
-0. Read the manual page for your system call (type `man 2 [system call name]` e.g. `man 2 execve`)
+0. Read the manual page for your system call (type `man 2 <system call name>` e.g. `man 2 execve`)
 
     0. Use this to answer questions 2, 3, and 4
 

--- a/assignments/P0.md
+++ b/assignments/P0.md
@@ -24,7 +24,7 @@ The objective of this assignment is to build a UNIX style shell.
 
     * You may find it prudent, and later expedient, to implement tests to ensure correctness of the code at each level
 
-    * Use `git commit --amend` to fix mistakes in the most recent commit, and explore `man git-rebase` for more complex revision
+    * Use `$ git commit --amend` to fix mistakes in the most recent commit, and explore `$ man git-rebase` for more complex revision
 
     * Each patch should describe important details of feature implementation
 
@@ -49,7 +49,7 @@ The objective of this assignment is to build a UNIX style shell.
 ### Levels:
 
 0. The shell prints a prompt, which consists of the absolute path the shell is currently
-running in (see `man 3 getcwd`) followed by a $ and a space
+running in (see `$ man 3 getcwd`) followed by a $ and a space
 (e.g. `/your/current/directory$ `). The shell then prints a new line and exits without
 any user interaction.
 
@@ -63,9 +63,9 @@ at which point it exits with code 0.
 no error message is printed.
 
 0. The shell splits the line of input into pieces delimited by whitespace characters
-(see `man 3 isspace`). Instead of just printing "Unrecognized command,"
+(see `$ man 3 isspace`). Instead of just printing "Unrecognized command,"
 the shell shall include the name of the program in the error message
-(e.g. if the user types `cat shell.c`, the shell prints "Unrecognized command: cat").
+(e.g. if the user types `$ cat shell.c`, the shell prints "Unrecognized command: cat").
 If the user enters only whitespace, no error message is printed.
 
 0. The shell supports a few builtin commands.
@@ -87,8 +87,8 @@ is printed, and the shell continues running.
 
 0. The shell supports running executable files as commands within child processes.
 If the first piece of the input looks like a relative or absolute path (contains a `/`),
-a child process is created (see `man 2 fork`), and the command specified by the first
-argument is executed within the child using the provided arguments (see `man 2 execve`),
+a child process is created (see `$ man 2 fork`), and the command specified by the first
+argument is executed within the child using the provided arguments (see `$ man 2 execve`),
 similar to the `exec` builtin.
 <br><br>
     If executing the command fails,
@@ -112,8 +112,8 @@ the shell performs home directory substitution on the pieces (command name or ar
 that start with a `~`. It should first determine a username string by taking a substring
 of the piece after the `~` until the end of the string or the first `/`,
 whichever comes first.
-    * If the username string is empty, then the `~` is replaced with the value of the `HOME` environment variable (see `man 3 getenv`)
-    * If the username string is not empty, the shell attempts to locate the user with that username and, if successful, replaces the `~` and the username substring with their home directory (see `man 3 getpwnam`)
+    * If the username string is empty, then the `~` is replaced with the value of the `HOME` environment variable (see `$ man 3 getenv`)
+    * If the username string is not empty, the shell attempts to locate the user with that username and, if successful, replaces the `~` and the username substring with their home directory (see `$ man 3 getpwnam`)
     * If `getpwnam` does not locate such a user, the shell leaves the piece unmodified
         * **Note:** in this case, `valgrind` may report a leak[^1]
 
@@ -127,14 +127,14 @@ an error message is printed.
 If there are multiple of the same redirections, then the right-most one takes precedence.
 A redirection causes the shell to open the corresponding file and replace one (or both)
 of the child process' IO streams with the file descriptor of the open file
-(see `man 2 dup`).
+(see `$ man 2 dup`).
 
     * `>` replaces stdout
     * `<` replaces stdin
 
 0. The shell supports the `|` (pipe) operator to chain multiple commands and their
 inputs and outputs. Each command separated by a `|` is spawned as its own child process.
-The shell creates a unidirectional pipe (see `man 2 pipe`) for each `|`, redirects
+The shell creates a unidirectional pipe (see `$ man 2 pipe`) for each `|`, redirects
 the stdout from the left command to the writing end of the pipe, and redirects the stdin
 of the right command to the reading end of the pipe.
 <br><br>

--- a/assignments/P1.md
+++ b/assignments/P1.md
@@ -26,9 +26,9 @@ Add a new system call to the kernel
 
         * Ignore the dashboard message about any detected whitespace errors
 
-    * Generate a single patch from your commit to the Linux kernel using the command `git format-patch -1` within your linux repo
+    * Generate a single patch from your commit to the Linux kernel using the command `$ git format-patch -1` within your linux repo
 
-    * Take the `.patch` file outputted, and put it in your named directory (e.g. `cp 0001*.patch ~/ILKD_Submissions/your_name/P1/syscall.patch`)
+    * Take the `.patch` file outputted, and put it in your named directory (e.g. `$ cp 0001*.patch ~/ILKD_Submissions/your_name/P1/syscall.patch`)
 
     * Add *the email patch itself* as a file named `syscall.patch` to the staged git files and commit this
 
@@ -104,21 +104,21 @@ Add a new system call to the kernel
 
     0. Update the `localversion` file to create a distinct release string so you can tell this kernel that has your system call apart from the other kernel you compiled
 
-    0. Update the config using `make oldconfig` (this should only take a few seconds, and shouldn't require you to answer any questions)
+    0. Update the config using `$ make oldconfig` (this should only take a few seconds, and shouldn't require you to answer any questions)
 
-    0. Before compiling the entire kernel, you will find it helpful to compile your new kdlp.c file in isolation using `make kernel/kdlp.o`
+    0. Before compiling the entire kernel, you will find it helpful to compile your new kdlp.c file in isolation using `$ make kernel/kdlp.o`
 
-    0. Compile your new kernel with `make -j $(nproc)`
+    0. Compile your new kernel with `$ make -j $(nproc)`
 
-    0. If the command finishes, make sure it was successful: `echo $?` should output `0`
+    0. If the command finishes, make sure it was successful: `$ echo $?` should output `0`
 
         * If it does not, re-run `make` without `-j $(nproc)` to get a better error message
 
-        * Fix whatever issue you see, and re-run `make -j $(nproc)`
+        * Fix whatever issue you see, and re-run `$ make -j $(nproc)`
 
         * Repeat this process of checking the result and fixing any errors until it compiles successfully
 
-    0. Install your new kernel and its modules `sudo make -j $(nproc) modules_install install`
+    0. Install your new kernel and its modules `$ sudo make -j $(nproc) modules_install install`
 
 0. Reboot your VM and pick the new kernel
 
@@ -128,11 +128,11 @@ Add a new system call to the kernel
 
 0. Make a patch out of your kernel code
 
-    * Find all untracked files, and files you modified by looking at the output of `git status` within your linux kernel repository
+    * Find all untracked files, and files you modified by looking at the output of `$ git status` within your linux kernel repository
 
-    * Add them to the staging area with `git add` and then run `git commit -s` and provide a message
+    * Add them to the staging area with `$ git add` and then run `$ git commit -s` and provide a message
 
-    * Format the resulting patch as a `.patch` file with `git format-patch -1`
+    * Format the resulting patch as a `.patch` file with `$ git format-patch -1`
 
         * You don't need `--rfc` or `-v1` or `--cover-letter` because this `.patch` is not getting emailed directly
 

--- a/assignments/setup.md
+++ b/assignments/setup.md
@@ -140,7 +140,7 @@ will allow the `whoami` command to execute and output `root`.
 
 Although you allocated the requisite 50+G of space, Fedora defaults to only using 15G for your filesystem. You can resize it to use all available space with:
 ```
-lvextend -r -l +100%free /dev/fedora/root
+$ lvextend -r -l +100%free /dev/fedora/root
 ```
 
 **At this point, you can go no further without** `dnf update -y` **finishing.


### PR DESCRIPTION
Edited all shell commands in assignments to use the `$ <command>` convention.

Addresses #74, at least as far as it pertains to assignments. 