### PR TITLE
Fixes #83: final_pres_guide: Fixed typo in final presentation guide document

### DIFF
--- a/assignments/final_pres_guide.md
+++ b/assignments/final_pres_guide.md
@@ -91,7 +91,7 @@ and reflect on what you've learned in the course.
 
         - How will your approach differ if you did it again?
 
-	- Pick and assignment you excelled at:
+	- Pick an assignment you excelled at:
 
 		- What made your work exceptional?
 


### PR DESCRIPTION
Fixes #83:  Fixed typo in final presentation guide document


Fixed a typo near the end of assignments/final_pres_guide.md where it said "Pick and assignment you excelled at". Now it says "Pick an assignment you excelled at".

Signed-off-by: root <root@SK-ASUS.>