### PR TITLE
Fixes #83: Fixed typo in final presentation guidelines

### DIFF
--- a/assignments/final_pres_guide.md
+++ b/assignments/final_pres_guide.md
@@ -79,7 +79,7 @@ and reflect on what you've learned in the course.
 
             - How will your approach differ if you did it again?
 
-        - Pick and assignment you excelled at:
+        - Pick an assignment you excelled at:
 
             - What made your work exceptional?
 


### PR DESCRIPTION
Fixes https://github.com/underground-software/ILKD_course_materials/issues/83: Fixed typo in final presentation guide document

Fixed a typo near the end of assignments/final_pres_guide.md where it said "Pick and assignment you excelled at". Now it says "Pick an assignment you excelled at".

Signed-off-by: sriram krishnamoorthy <sriramk1000@gmail.com>