### PR TITLE
Update commit instructions in new_syscall.md

### DIFF
--- a/assignments/new_syscall.md
+++ b/assignments/new_syscall.md
@@ -242,7 +242,7 @@ For the purposes of grading, this assignment will be part of the "Homework Exerc
 
 0. Run `qemu` with your original kernel and your new init program again, capturing the output in `~/submissions/$USER/new_syscall/original_output.txt`
 
-    * You can now make your third commit for the assignment
+    * You can now make your fourth commit for the assignment
 
 0. Extra Credit opportunity:
 


### PR DESCRIPTION
The instruction "You can make your third commit" is used twice, for both the third and fourth commit. This was fixed by adding "You can make your fourth commit" where it should be, in step 8.