### PR TITLE
Additional tests under patch 4

### DIFF
--- a/assignments/character_device.md
+++ b/assignments/character_device.md
@@ -28,7 +28,7 @@ Your colleague's tests will pass when run against your implementation.
 
     * The `clean` target of this makefile must remove all module build artifacts
 
-* Patch 3 adds additional tests to the provided program
+* Patch 4 adds additional tests to the provided program
 
 * Don't forget a cover letter
 


### PR DESCRIPTION
The final step of the specification states that the 5 additional test cases should be passed by the module added to the previous patch. The what to submit section has the module code and the additional tests as the same patch number. This pull request changes the patch number for the additional tests from 3 to 4 under the 'what to submit' portion to rectify this discrepancy.